### PR TITLE
docs: add community feedback call-to-action to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ pytest -v
 
 We welcome contributions from everyone, especially neurodivergent developers! Please read our [Contributing Guide](.github/CONTRIBUTING.md) to get started.
 
+## 💬 Community Feedback (5–10 Minute Review)
+
+Want to help shape HyperCode quickly? Start here:
+
+1. Read this README and the [Getting Started Guide](docs/getting_started.md).
+2. Share first impressions:
+   - What feels clear vs confusing?
+   - What excites you most (or least)?
+   - Which part should we simplify first?
+3. Post feedback where maintainers can action it fastest:
+   - [GitHub Issues](https://github.com/welshDog/HyperCode-V2.0/issues) for bugs, feature requests, or clarity gaps.
+   - [GitHub Discussions](https://github.com/welshDog/HyperCode-V2.0/discussions) for open-ended ideas and design debate.
+
+If you have time for a deeper review, see [docs/architecture.md](docs/architecture.md), [docs/security_threat_model.md](docs/security_threat_model.md), and [docs/traceability_matrix.md](docs/traceability_matrix.md), then open a PR or issue with your recommendations.
+
 ---
 
 ## 📜 License


### PR DESCRIPTION
### Motivation
- Provide a low-friction, 5–10 minute path for newcomers to give actionable feedback and convert interest into issues, discussions, or PRs.

### Description
- Added a new `Community Feedback (5–10 Minute Review)` section to `README.md` with a short checklist for first impressions, links to `GitHub Issues` and `GitHub Discussions`, and pointers for deeper technical review. 

### Testing
- Verified the new README section by inspecting the file diff and line output and confirmed referenced docs exist using `test -f docs/QUICKSTART.md` and similar file-existence checks, all of which returned success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c308fe348328a6cbcf4924eb3cc0)